### PR TITLE
Raise Embulk Error

### DIFF
--- a/lib/embulk/input/elasticsearch/connection.rb
+++ b/lib/embulk/input/elasticsearch/connection.rb
@@ -73,8 +73,8 @@ module Embulk
               sleep 2**retries
               retry
             end
-            Embulk.logger.error "Could not search to Elasticsearch after #{retries} retries. #{e.message}"
-            return nil
+            msg = "Could not search to Elasticsearch after #{retries} retries. #{e.message}"
+            raise Elasticsearch::ConfigError(e, msg)
           end
         end
 

--- a/lib/embulk/input/elasticsearch/converter.rb
+++ b/lib/embulk/input/elasticsearch/converter.rb
@@ -40,7 +40,7 @@ module Embulk
           when "json"
             value
           else
-            raise "Unsupported type #{field['type']}"
+            raise Elasticsearch::TypecastError.new "Unsupported type #{field['type']}"
           end
         end
       end

--- a/lib/embulk/input/elasticsearch/error.rb
+++ b/lib/embulk/input/elasticsearch/error.rb
@@ -1,0 +1,36 @@
+module Embulk
+  module Input
+
+    class Elasticsearch < InputPlugin
+
+      module Traceable
+        def initialize(e, more_msg = nil)
+          message = e.is_a?(String) ? '' : "(#{e.class}) "
+          message << "#{e}#{more_msg}\n"
+          message << "\tat #{e.backtrace.join("\n\tat ")}\n" if e.respond_to?(:backtrace)
+
+          while e.respond_to?(:cause) and e.cause
+            # Java Exception cannot follow the JRuby causes.
+            message << "Caused by (#{e.cause.class}) #{e.cause}\n"
+            message << "\tat #{e.cause.backtrace.join("\n\tat ")}\n" if e.cause.respond_to?(:backtrace)
+            e = e.cause
+          end
+
+          super(message)
+        end
+      end
+
+      class ConfigError < ::Embulk::ConfigError
+        include Traceable
+      end
+
+      class DataError < ::Embulk::DataError
+        include Traceable
+      end
+
+      class TypecastError < DataError
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
If some error happens, Embulk should fail. It seems like Embulk exits without problems when the connection is refused by network problem e.g. firewall. Typecast follow the same policy. 

```
2019-07-19 08:13:26.929 +0000 [ERROR] (0015:task-0000): Could not search to Elasticsearch after 5 retries. [403] {"Message":"User: anonymous is not authorized to perform: es:ESHttpGet"}
```

This PR does not contain test, please let me know the rest of the task.

Ref for error type
https://github.com/medjed/embulk-input-google_spreadsheets/blob/master/lib/embulk/input/google_spreadsheets/error.rb